### PR TITLE
fix: turn non nullable ActivityLifecycleCallbacks

### DIFF
--- a/.github/workflows/validate_danger.yaml
+++ b/.github/workflows/validate_danger.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: "Danger Run"
         run: yarn danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.QWKIN_TOKEN_OS }}
+          GITHUB_TOKEN: ${{ secrets.QWKIN_TOKEN_OS }}
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/packages/torch_controller/android/src/main/kotlin/com/example/torch_controller/TorchControllerPlugin.kt
+++ b/packages/torch_controller/android/src/main/kotlin/com/example/torch_controller/TorchControllerPlugin.kt
@@ -22,7 +22,7 @@ class TorchControllerPlugin(activity: Activity) : MethodCallHandler {
     torchImpl = Torch(activity)
 
     activity.application.registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks() {
-      override fun onActivityStopped(activity: Activity?) {
+      override fun onActivityStopped(activity: Activity) {
         torchImpl.dispose()
       }
     })

--- a/packages/torch_controller/android/src/main/kotlin/com/example/torch_controller/utils/ActivityLifecycleCallbacks.kt
+++ b/packages/torch_controller/android/src/main/kotlin/com/example/torch_controller/utils/ActivityLifecycleCallbacks.kt
@@ -5,24 +5,24 @@ import android.app.Application
 import android.os.Bundle
 
 open class ActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
-    override fun onActivityPaused(activity: Activity?) {
+    override fun onActivityPaused(activity: Activity) {
     }
 
-    override fun onActivityResumed(activity: Activity?) {
+    override fun onActivityResumed(activity: Activity) {
     }
 
-    override fun onActivityStarted(activity: Activity?) {
+    override fun onActivityStarted(activity: Activity) {
     }
 
-    override fun onActivityDestroyed(activity: Activity?) {
+    override fun onActivityDestroyed(activity: Activity) {
     }
 
-    override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
     }
 
-    override fun onActivityStopped(activity: Activity?) {
+    override fun onActivityStopped(activity: Activity) {
     }
 
-    override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
     }
 }

--- a/packages/torch_controller/example/pubspec.lock
+++ b/packages/torch_controller/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   torch_controller:
     dependency: "direct main"
     description:
@@ -157,4 +157,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/torch_controller/pubspec.lock
+++ b/packages/torch_controller/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

ActivityLifecycleCallbacks returns error using https://pub.dev/packages/permission_handler

## Related Issues

https://github.com/4itworks/opensource_qwkin_dart/issues/7

## Developer checklist

- [ ] All existing and new tests are passing.
- [ ] All github actions are passing.

## Breaking Change

Does your PR require users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Minor Change

Does your PR does significant semantic change? (A lot of design changes, architecture changes...)

- [ ] Yes, this is a minor change.
- [ ] No, this is *not* a minor change.

## Screenshots

<!--
    Before you submit your PR, please provide screenshots for the work you have done, if that is the case
-->

## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has automated tests (if is the case)
- This PR is not as Draft
