### PR TITLE
Added Android support for api lvl 21

### DIFF
--- a/packages/torch_controller/android/build.gradle
+++ b/packages/torch_controller/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 21
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Android Compatibility: Support for API Level 21


## Description

Added Android support for api lvl 21 in app build gradle file.
Apps targeting Android 5.0 can also use this plugin now.


## Related Issues

Closes #9 

## Developer checklist

- [X] All existing and new tests are passing.
- [X] All github actions are passing.

## Breaking Change

Does your PR require users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Minor Change

Does your PR does significant semantic change? (A lot of design changes, architecture changes...)

- [X] Yes, this is a minor change.
- [ ] No, this is *not* a minor change.
