### PR TITLE
Restore support for Android API v21

### DIFF
--- a/packages/torch_controller/android/build.gradle
+++ b/packages/torch_controller/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 21
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/torch_controller/example/android/app/build.gradle
+++ b/packages/torch_controller/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.torch_control_example"
-        minSdkVersion 23
+        minSdkVersion 21
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
## Description

Restores support for Android API Level 21.

## Related Issues

Closes [#22]([https://github.com/4itworks/opensource_qwkin_dart/issues/22])

## Developer checklist

- [x] All existing and new tests are passing.
- [ ] All github actions are passing.

## Breaking Change

Does your PR require users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Minor Change

Does your PR does significant semantic change? (A lot of design changes, architecture changes...)

- [x] Yes, this is a minor change.
- [ ] No, this is *not* a minor change.