### PR TITLE
Add namespaces to build.gradle for AGP8+ support

### DIFF
--- a/packages/torch_controller/android/build.gradle
+++ b/packages/torch_controller/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    namespace 'com.livviellc.torch_controller'
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/packages/torch_controller/android/build.gradle
+++ b/packages/torch_controller/android/build.gradle
@@ -38,6 +38,15 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {

--- a/packages/torch_controller/android/src/main/AndroidManifest.xml
+++ b/packages/torch_controller/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.torch_controller">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FLASHLIGHT" />


### PR DESCRIPTION
## Description
When i tried to run my app with Torch Controller installed on Android. I got a '[Namespace not specified for AGP 8.0.0](https://discuss.gradle.org/t/namespace-not-specified-for-agp-8-0-0/45850)' error during building phase after upgrading AGP to 8.0+. This is because AGP 8.0+ have a breaking changes that required [namespace in the module-level build script.](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes)

I also removed package attributes in AndroidManifest to prevent ```Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.``` error during build phase. Feel free to edit your own namespaces before updating your package in pub.dev. 

I also added JVM toolchain [compatibility](https://stackoverflow.com/questions/69079963/how-to-set-compilejava-task-11-and-compilekotlin-task-1-8-jvm-target-com).

Tested on my app using OPPO Reno 5 Pro (API 33) and Android API 34 emulator.

## Developer checklist

<!--
  Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
  This will ensure a smooth and quick review process.
-->

- [ ] All existing and new tests are passing.
- [ ] All github actions are passing.

## Breaking Change

Does your PR require users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Minor Change

Does your PR does significant semantic change? (A lot of design changes, architecture changes...)

- [x] Yes, this is a minor change.
- [ ] No, this is *not* a minor change.

## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has automated tests (if is the case)
- This PR is not as Draft
